### PR TITLE
template function  need previous declaration

### DIFF
--- a/source/utf8/checked.h
+++ b/source/utf8/checked.h
@@ -33,6 +33,9 @@ DEALINGS IN THE SOFTWARE.
 
 namespace utf8
 {
+    template <typename octet_iterator>
+        octet_iterator append(uint32_t cp, octet_iterator result);
+
     // Exceptions that may be thrown from the library functions.
     class invalid_code_point : public std::exception {
         uint32_t cp;


### PR DESCRIPTION
The template function `append` in utf8/checked.h need an previous declaration. Otherwise，you will get an compile error when you call those function like utf8::replace_invalid which using `append` but define after it.